### PR TITLE
Incorporated Carl's suggetion. Closes #28

### DIFF
--- a/CSR-ATTESTATION-2023.asn
+++ b/CSR-ATTESTATION-2023.asn
@@ -14,20 +14,22 @@ Certificate
      mechanisms(5) pkix(7) id-mod(0) id-mod-pkix1-explicit-02(51)}
 
 
-EXTENSION, ATTRIBUTE, AttributeSet{}, SingleAttribute{}, id-pkix 
+EXTENSION, ATTRIBUTE, AttributeSet{}, SingleAttribute{}
     FROM PKIX-CommonTypes-2009 -- from [RFC5912]
     { iso(1) identified-organization(3) dod(6) internet(1) security(5)
       mechanisms(5) pkix(7) id-mod(0) id-mod-pkixCommon-02(57) }
 
-id-aa
-FROM SecureMimeMessageV3dot1
-    { iso(1) member-body(2) us(840) rsadsi(113549)
-        pkcs(1) pkcs-9(9) smime(16) modules(0) msg-v3dot1(21) }
   ;
 
+id-aa OBJECT IDENTIFIER ::= 
+    { iso(1) member-body(2) us(840) rsadsi(113549)
+        pkcs(1) pkcs-9(9) smime(16) 9 }
+
+id-pkix OBJECT IDENTIFIER ::= {iso(1) identified-organization(3) dod(6) internet(1) security(5)
+     mechanisms(5)7 }
 
 -- Branch for attestation statement types
-id-ata OBJECT IDENTIFIER ::= { id-pkix ata(TBD1) }
+id-ata OBJECT IDENTIFIER ::= { id-pkix 9991 }
 
 
 CertificateChoice ::=
@@ -63,7 +65,7 @@ EvidenceStatementSet EVIDENCE-STATEMENT ::= {
    ... -- Empty for now --
 }
  
-EvidenceStatement {EVIDENCE-STATEMENT:EvidenceStatementSet} ::= SEQUENCE {
+EvidenceStatement ::= SEQUENCE {
    type   EVIDENCE-STATEMENT.&id({EvidenceStatementSet}),
    stmt   EVIDENCE-STATEMENT.&Type({EvidenceStatementSet}{@type})
 }
@@ -72,37 +74,22 @@ id-aa-evidenceStatement OBJECT IDENTIFIER ::= { id-aa aa-evidenceStatement(TBDAA
 
 -- For PKCS#10
 attr-evidence ATTRIBUTE ::= {
-  TYPE SEQUENCE OF EvidenceBundle,
+  TYPE SEQUENCE OF EvidenceBundle
   IDENTIFIED BY id-aa-evidenceStatement
 }
 
 
 -- For CRMF
 ext-evidence EXTENSION ::= {
-  TYPE SEQUENCE OF EvidenceBundle,
+  SYNTAX SEQUENCE OF EvidenceBundle
   IDENTIFIED BY id-aa-evidenceStatement
 }
 
 EvidenceBundle ::= SEQUENCE
-  {
-    evidence  SEQUENCE OF EvidenceStatement,
-    certs SEQUENCE OF CertificateChoice OPTIONAL
-  }
-
-id-aa-evidenceChainCerts OBJECT IDENTIFIER ::= { id-aa aa-evidenceChainCerts(TBDAA1) }
-
--- For PKCS#10
-attr-evidenceCerts ATTRIBUTE ::= {
-  TYPE SEQUENCE OF CertificateChoice
-  COUNTS MAX 1
-  IDENTIFIED BY id-aa-evidenceChainCerts
+{
+  evidence  SEQUENCE OF EvidenceStatement,
+  certs SEQUENCE OF CertificateChoice OPTIONAL
 }
 
--- For CRMF
-ext-evidenceCerts EXTENSION ::= {
-  TYPE SEQUENCE OF CertificateChoice
-  COUNTS MAX 1
-  IDENTIFIED BY id-aa-evidenceChainCerts
-}
 
 END

--- a/CSR-ATTESTATION-2023.asn
+++ b/CSR-ATTESTATION-2023.asn
@@ -35,7 +35,8 @@ CertificateChoice ::=
       cert Certificate,
       opaqueCert    [0] IMPLICIT OCTET STRING,
       typedCert     [1] IMPLICIT TypedCert,
-      typedFlatCert [2] IMPLICIT TypedFlatCert
+      typedFlatCert [2] IMPLICIT TypedFlatCert,
+      ...
    }
 
 TYPED-CERT ::= TYPE-IDENTIFIER
@@ -71,15 +72,22 @@ id-aa-evidenceStatement OBJECT IDENTIFIER ::= { id-aa aa-evidenceStatement(TBDAA
 
 -- For PKCS#10
 attr-evidence ATTRIBUTE ::= {
-  TYPE EvidenceStatement
+  TYPE SEQUENCE OF EvidenceBundle,
   IDENTIFIED BY id-aa-evidenceStatement
 }
 
+
 -- For CRMF
 ext-evidence EXTENSION ::= {
-  TYPE EvidenceStatement
+  TYPE SEQUENCE OF EvidenceBundle,
   IDENTIFIED BY id-aa-evidenceStatement
 }
+
+EvidenceBundle ::= SEQUENCE
+  {
+    evidence  SEQUENCE OF EvidenceStatement,
+    certs SEQUENCE OF CertificateChoice OPTIONAL
+  }
 
 id-aa-evidenceChainCerts OBJECT IDENTIFIER ::= { id-aa aa-evidenceChainCerts(TBDAA1) }
 

--- a/CSR-ATTESTATION-2023.asn
+++ b/CSR-ATTESTATION-2023.asn
@@ -70,7 +70,7 @@ EvidenceStatement ::= SEQUENCE {
    stmt   EVIDENCE-STATEMENT.&Type({EvidenceStatementSet}{@type})
 }
 
-id-aa-evidenceStatement OBJECT IDENTIFIER ::= { id-aa aa-evidenceStatement(TBDAA2) }
+id-aa-evidenceStatement OBJECT IDENTIFIER ::= { id-aa TBDAA2 }
 
 -- For PKCS#10
 attr-evidence ATTRIBUTE ::= {

--- a/CSR-ATTESTATION-2023.asn
+++ b/CSR-ATTESTATION-2023.asn
@@ -8,7 +8,7 @@ EXPORTS ALL;
 
 IMPORTS
 
-Certificate
+Certificate, id-pkix
  FROM PKIX1Explicit-2009
      {iso(1) identified-organization(3) dod(6) internet(1) security(5)
      mechanisms(5) pkix(7) id-mod(0) id-mod-pkix1-explicit-02(51)}
@@ -19,17 +19,15 @@ EXTENSION, ATTRIBUTE, AttributeSet{}, SingleAttribute{}
     { iso(1) identified-organization(3) dod(6) internet(1) security(5)
       mechanisms(5) pkix(7) id-mod(0) id-mod-pkixCommon-02(57) }
 
-  ;
-
-id-aa OBJECT IDENTIFIER ::= 
+id-aa
+FROM SecureMimeMessageV3dot1
     { iso(1) member-body(2) us(840) rsadsi(113549)
-        pkcs(1) pkcs-9(9) smime(16) 9 }
-
-id-pkix OBJECT IDENTIFIER ::= {iso(1) identified-organization(3) dod(6) internet(1) security(5)
-     mechanisms(5)7 }
+        pkcs(1) pkcs-9(9) smime(16) modules(0) msg-v3dot1(21) }
+  ;
+  
 
 -- Branch for attestation statement types
-id-ata OBJECT IDENTIFIER ::= { id-pkix 9991 }
+id-ata OBJECT IDENTIFIER ::= { id-pkix (TBD1) }
 
 
 CertificateChoice ::=
@@ -70,7 +68,7 @@ EvidenceStatement ::= SEQUENCE {
    stmt   EVIDENCE-STATEMENT.&Type({EvidenceStatementSet}{@type})
 }
 
-id-aa-evidenceStatement OBJECT IDENTIFIER ::= { id-aa TBDAA2 }
+id-aa-evidenceStatement OBJECT IDENTIFIER ::= { id-aa TBDAA }
 
 -- For PKCS#10
 attr-evidence ATTRIBUTE ::= {

--- a/draft-ietf-lamps-csr-attestation.md
+++ b/draft-ietf-lamps-csr-attestation.md
@@ -221,7 +221,7 @@ This structure allows for grouping evidence statements that share a
 certificate chain.
 
 ~~~
-id-aa-evidenceStatement OBJECT IDENTIFIER ::= { id-aa (TBDAA2) }
+id-aa-evidenceStatement OBJECT IDENTIFIER ::= { id-aa TBDAA }
 
 -- For PKCS#10
 attr-evidence ATTRIBUTE ::= {
@@ -378,15 +378,10 @@ S/MIME Attributes" to identify two Attributes defined within.
 
 - Attest Statement
 
-  - Decimal: IANA Assigned - Replace TBDAA2
+  - Decimal: IANA Assigned - Replace TBDAA
   - Description: id-aa-evidenceStatement
   - References: This Document
 
-- Attest Certificate Chain
-
-  - Decimal: IANA Assigned - Replace TBDAA1
-  - Description: id-aa-evidenceChainCerts
-  - References: This Document
 
 ###  "SMI Security for PKIX Evidence Statement Formats" Registry
 
@@ -432,7 +427,7 @@ makes available to services. The Attesting Environment collects
 these claims about the Target Environment and signs them and
 exports Evidence for use in remote attestation via a CSR.
 
-~~~
+~~~ aasvg
                    ^
                    |CSR with
                    |Evidence

--- a/draft-ietf-lamps-csr-attestation.md
+++ b/draft-ietf-lamps-csr-attestation.md
@@ -41,6 +41,7 @@ author:
     name: Hannes Tschofenig
     organization: Siemens
     email: Hannes.Tschofenig@gmx.net
+
   - name: Henk Birkholz
     org: Fraunhofer SIT
     abbrev: Fraunhofer SIT
@@ -213,27 +214,46 @@ id-ata OBJECT IDENTIFIER ::= { id-pkix (TBD1) }
 By definition, Attributes within a PKCS#10 CSR are
 typed as ATTRIBUTE and within a CRMF CSR are typed as EXTENSION.
 This attribute definition contains one or more
-evidence statements of a type "EvidenceStatement".
+evidence bundles of type `EvidenceBundle` which each contain
+one or more evidence statements of a type `EvidenceStatement` along with
+an optional certificate chain.
+This structure allows for grouping evidence statements that share a
+certificate chain.
 
 ~~~
 id-aa-evidenceStatement OBJECT IDENTIFIER ::= { id-aa (TBDAA2) }
 
 -- For PKCS#10
 attr-evidence ATTRIBUTE ::= {
-  TYPE EvidenceStatement
+  TYPE SEQUENCE OF EvidenceBundle,
   IDENTIFIED BY id-aa-evidenceStatement
 }
+
 
 -- For CRMF
 ext-evidence EXTENSION ::= {
-  TYPE EvidenceStatement
+  TYPE SEQUENCE OF EvidenceBundle,
   IDENTIFIED BY id-aa-evidenceStatement
 }
+
+EvidenceBundle ::= SEQUENCE
+  {
+    evidence  SEQUENCE OF EvidenceStatement,
+    certs SEQUENCE OF CertificateChoice OPTIONAL
+  }
 ~~~
 
-A CSR MAY contain one or more instance of `EvidenceAttribute`.
-
 The Extension version is intended only for use within CRMF CSRs and is NOT RECOMMENDED for use within X.509 certificates due to the privacy implications of publishing evidence about the end entity's hardware environment. See {{security-considerations}} for more discussion.
+
+
+A CSR MAY contain one or more instance of `attr-evidence` or `ext-evidence`.
+This means that the `SEQUENCE OF EvidenceBundle` is redundant with the
+ability to carry multiple `attr-evidence` or `ext-evidence` at the CSR level;
+either mechanism MAY be used for carrying multiple evidence bundles.
+We are leaving the `SEQUENCE OF EvidenceBundle` since it is in general
+more flexible than relying on the containing structure to handle multiplicity
+and allows for this structure to be re-used in the future in other PKIX
+protocol contexts.
 
 
 ##  EvidenceStatement

--- a/draft-ietf-lamps-csr-attestation.md
+++ b/draft-ietf-lamps-csr-attestation.md
@@ -236,17 +236,25 @@ ext-evidence EXTENSION ::= {
   IDENTIFIED BY id-aa-evidenceStatement
 }
 
-EvidenceBundle ::= SEQUENCE
-  {
+EvidenceBundle ::= SEQUENCE {
     evidence  SEQUENCE OF EvidenceStatement,
     certs SEQUENCE OF CertificateChoice OPTIONAL
   }
 ~~~
 
-The Extension version is intended only for use within CRMF CSRs and is NOT RECOMMENDED for use within X.509 certificates due to the privacy implications of publishing evidence about the end entity's hardware environment. See {{security-considerations}} for more discussion.
+The Extension version is intended only for use within CRMF CSRs and MUST NOT be used within X.509 certificates due to the privacy implications of publishing evidence about the end entity's hardware environment. See {{security-considerations}} for more discussion.
+
+The `certs` contains a set of certificates that
+may be needed to validate the contents of an evidence statement
+contained in `evidence`. The set of certificates should contain
+the object that contains the public key needed to directly validate the
+`evidence`.  The remaining elements should chain that data back to
+an agreed upon trust anchor used for attestation. No order is implied, it is
+up to the Attester and its Verifier to agree on both the order and format
+of certificates contained in `certs`.
 
 
-A CSR MAY contain one or more instance of `attr-evidence` or `ext-evidence`.
+A CSR MAY contain one or more instances of `attr-evidence` or `ext-evidence`.
 This means that the `SEQUENCE OF EvidenceBundle` is redundant with the
 ability to carry multiple `attr-evidence` or `ext-evidence` at the CSR level;
 either mechanism MAY be used for carrying multiple evidence bundles.
@@ -273,7 +281,7 @@ EvidenceStatementSet EVIDENCE-STATEMENT ::= {
    ... -- Empty for now --
 }
 
-EvidenceStatement {EVIDENCE-STATEMENT:EvidenceStatementSet} ::= SEQUENCE {
+EvidenceStatement ::= SEQUENCE {
    type   EVIDENCE-STATEMENT.&id({EvidenceStatementSet}),
    stmt   EVIDENCE-STATEMENT.&Type({EvidenceStatementSet}{@type})
 }
@@ -292,44 +300,6 @@ ext-evidence EXTENSION ::= {
   IDENTIFIED BY id-aa-evidenceStatement
 }
 ~~~
-
-##  EvidenceCerts
-
-The "EvidenceCertsAttribute" contains a set of certificates that
-may be needed to validate the contents of an evidence statement
-contained in an evidenceAttribute. The set of certificates should contain
-the object that contains the public key needed to directly validate the
-EvidenceAttribute.  The remaining elements should chain that data back to
-an agreed upon trust anchor used for attestation. No order is implied, it is
-the Verifier's responsibility to perform the appropriate certification path
-construction.
-
-A CSR MUST contain at zero or one `EvidenceCertsAttribute`. In the case where
-the CSR contains multiple instances of `EvidenceAttribute` representing
-multiple evidence statements, all necessary certificates MUST be contained in
-the same instance of `EvidenceCertsAttribute`.
-`EvidenceCertsAttribute` MAY be omitted if there are no certificates to convey, for example if they are already known to the verifier, or if they are contained in the evidence statement.
-
-
-~~~
-id-aa-evidenceChainCerts OBJECT IDENTIFIER ::= { id-aa (TBDAA1) }
-
--- For PKCS#10
-attr-evidenceCerts ATTRIBUTE ::= {
-  TYPE SEQUENCE OF CertificateChoice
-  COUNTS MAX 1
-  IDENTIFIED BY id-aa-evidenceChainCerts
-}
-
--- For CRMF
-ext-evidenceCerts EXTENSION ::= {
-  TYPE SEQUENCE OF CertificateChoice
-  COUNTS MAX 1
-  IDENTIFIED BY id-aa-evidenceChainCerts
-}
-~~~
-
-The Extension version is intended only for use within CRMF CSRs and is NOT RECOMMENDED for use within X.509 certificates due to the privacy implications of publishing evidence about the end entity's hardware environment. See {{security-considerations}} for more discussion.
 
 ##  CertificateChoice
 


### PR DESCRIPTION
The ASN.1 is not currently compiling. I get:

```
line 88 (CSR-ATTESTATION-2023): A0201E: 'EvidenceStatement' is being used as a typereference, but has been used elsewhere in the current module as a parameterized typereference.
    evidence  SEQUENCE OF EvidenceStatement,
                          ^
```

I really don't understand these generics in ASN.1. Help please @mcr , @hannestschofenig , @henkbirkholz , @carl-wallace 