### PR TITLE
Update draft-ietf-lamps-csr-attestation.md

### DIFF
--- a/draft-ietf-lamps-csr-attestation.md
+++ b/draft-ietf-lamps-csr-attestation.md
@@ -861,17 +861,6 @@ these evidence formats, and so we leave the OIDs as TBD1 / TBD2.
 
 This section describes TPM2 key attestation for use in a CSR.
 
-### Introduction to TPM2 concepts
-
-The defininitions in the following sections are defined by the TPM2 and various TCG defined
-specification including the TPM2 set of specifications. Those familiar with
-TPM2 concepts may skip to {{appdx-tcg-attest-certify}} which defines an ASN.1 structure
-specific for bundling a TPM attestation into an EvidenceStatement, and {{appdx-tpm-example}}
-which provides the example. For those unfamiliar with TPM2 concepts
-this section provides only the minimum information to understand TPM2
-Attestation in CSR and is not a complete description of the technology in
-general.
-
 ### TCG Key Attestation Certify
 
 There are several ways in TPM2 to provide proof of a key's properties.
@@ -909,7 +898,16 @@ tcg-attest-certify ::= SEQUENCE {
 ~~~
 
 The tcg-kp-AIKCertificate field contains the AIK Certificate in RFC 5280 format.
+## Introduction to TPM2 concepts
 
+The defininitions in the following sections are defined by the TPM2 and various TCG defined
+specification including the TPM2 set of specifications. Those familiar with
+TPM2 concepts may skip to {{appdx-tcg-attest-certify}} which defines an ASN.1 structure
+specific for bundling a TPM attestation into an EvidenceStatement, and {{appdx-tpm-example}}
+which provides the example. For those unfamiliar with TPM2 concepts
+this section provides only the minimum information to understand TPM2
+Attestation in CSR and is not a complete description of the technology in
+general.
 
 ### TCG Objects and Key Attestation
 


### PR DESCRIPTION
Move section "Introduction to TPM2 concepts" from top of example to be the introduction to the entire section describing the TPM2's structures.