### PR TITLE
Replaced TypedCert with CertificateChoices from RFC6268

### DIFF
--- a/CSR-ATTESTATION-2023.asn
+++ b/CSR-ATTESTATION-2023.asn
@@ -13,6 +13,10 @@ Certificate, id-pkix
      {iso(1) identified-organization(3) dod(6) internet(1) security(5)
      mechanisms(5) pkix(7) id-mod(0) id-mod-pkix1-explicit-02(51)}
 
+CertificateChoices
+FROM CryptographicMessageSyntax-2010
+{ iso(1) member-body(2) us(840) rsadsi(113549)
+pkcs(1) pkcs-9(9) smime(16) modules(0) id-mod-cms-2009(58) }
 
 EXTENSION, ATTRIBUTE, AttributeSet{}, SingleAttribute{}
     FROM PKIX-CommonTypes-2009 -- from [RFC5912]
@@ -87,10 +91,10 @@ ext-evidence EXTENSION ::= {
 
 EvidenceBundles ::= SEQUENCE SIZE (1..MAX) OF EvidenceBundle
 
-EvidenceBundle ::= SEQUENCE
-{
-  evidence EvidenceStatements,
-  certs SEQUENCE SIZE (1..MAX) OF CertificateAlternatives OPTIONAL
+EvidenceBundle ::= SEQUENCE {
+   evidence EvidenceStatements,
+   certs SEQUENCE SIZE (1..MAX) OF CertificateChoices OPTIONAL
+      -- CertificateChoices MUST only contain certificate or other
 }
 
 

--- a/draft-ietf-lamps-csr-attestation.md
+++ b/draft-ietf-lamps-csr-attestation.md
@@ -565,7 +565,7 @@ EvidenceBundle ::= SEQUENCE {
 }
 ~~~
 
-The CertificateChoices structure defined in [RFC6268] allows for carrying certificates in the default X.509 [RFC5280] format, or in other non-X.509 certificate formats. CertificateChoices MUST only contain certificate or other. CertificateChoices MUST NOT contain extendedCertificate, v1AttrCert, or v2AttrCert. Note that for non-ASN.1 certificate formats, the CertificateChoices can use `other [3]` with an `OtherCertificateFormat.Type` of `OCTET STRING`, and then can carry any binary data.
+The CertificateChoices structure defined in [RFC6268] allows for carrying certificates in the default X.509 [RFC5280] format, or in other non-X.509 certificate formats. CertificateChoices MUST only contain certificate or other. CertificateChoices MUST NOT contain extendedCertificate, v1AttrCert, or v2AttrCert. Note that for non-ASN.1 certificate formats, the CertificateChoices MUST use `other [3]` with an `OtherCertificateFormat.Type` of `OCTET STRING`, and then can carry any binary data.
 
 
 ~~~

--- a/draft-ietf-lamps-csr-attestation.md
+++ b/draft-ietf-lamps-csr-attestation.md
@@ -323,11 +323,10 @@ certificates.
  +--------+-----------+
           |
           |           (1 or more) +-------------------------+
-          |         +-------------+ CertificateAlternatives |
+          |         +-------------+ CertificateChoices      |
           |         |             +-------------------------+
           |         |             | Certificate OR          |
-          |         |             | TypedCert   OR          |
-          |         |             | TypedFlatCert           |
+          |         |             | OtherCertificateFormat  |
    (1 or  |         |             +-------------------------+
     more) |         |      (1 or
  +--------+---------+-+     more) +-------------------+

--- a/draft-ietf-lamps-csr-attestation.md
+++ b/draft-ietf-lamps-csr-attestation.md
@@ -60,6 +60,7 @@ author:
 
 normative:
   RFC9334:
+  RFC6268:
   RFC5912:
   RFC4211:
   RFC2986:
@@ -530,12 +531,17 @@ id-TcgAttestCertify, while the hint indicates the the Verifier software
 ~~~
 EvidenceBundles ::= SEQUENCE SIZE (1..MAX) OF EvidenceBundle
 
-EvidenceBundle ::= SEQUENCE
-{
-  evidence EvidenceStatements,
-  certs SEQUENCE SIZE (1..MAX) OF CertificateAlternatives OPTIONAL
+EvidenceBundle ::= SEQUENCE {
+   evidence EvidenceStatements,
+   certs SEQUENCE SIZE (1..MAX) OF CertificateChoices OPTIONAL
+      -- CertificateChoices MUST only contain certificate or other
 }
+~~~
 
+The CertificateChoices structure defined in [RFC6268] allows for carrying certificates in the default X.509 [RFC5280] format, or in other non-X.509 certificate formats. CertificateChoices MUST only contain certificate or other. CertificateChoices MUST NOT contain extendedCertificate, v1AttrCert, or v2AttrCert. Note that for non-ASN.1 certificate formats, the CertificateChoices can use `other [3]` with an `OtherCertificateFormat.Type` of `OCTET STRING`, and then can carry any binary data.
+
+
+~~~
 id-aa-evidence OBJECT IDENTIFIER ::= { id-aa 59 }
 
 -- For PKCS#10
@@ -567,63 +573,6 @@ This means that the `SEQUENCE OF EvidenceBundle` is redundant with the
 ability to carry multiple `attr-evidence` or `ext-evidence` at the CSR level;
 either mechanism MAY be used for carrying multiple Evidence bundles.
 
-
-##  CertificateAlternatives
-
-This is an ASN.1 CHOICE construct used to represent an encoding of a
-broad variety of certificate types.
-
-~~~
-CertificateAlternatives ::=
-   CHOICE {
-      cert              Certificate,
-                           -- Using the Certificate ASN.1
-                           -- structure as defined in RFC 5280.
-      typedCert     [0] TypedCert,
-      typedFlatCert [1] TypedFlatCert,
-      ...
-   }
-~~~
-
-"Certificate" is a standard X.509 certificate that MUST be compliant
-with RFC 5280.
-Enforcement of this constraint is left to the relying
-parties.
-
-"TypedCert" is an ASN.1 construct that has the characteristics of a
-certificate, but is not encoded as an X.509 certificate.  The
-certType Field (below) indicates how to interpret the certBody field.  While
-it is possible to carry any type of data in this structure, it's
-intended the content field include data for at least one public key
-formatted as a SubjectPublicKeyInfo (see {{RFC5912}}).
-
-~~~
-TYPED-CERT ::= TYPE-IDENTIFIER
-
-CertType ::= TYPED-CERT.&id
-
-TypedCert ::= SEQUENCE {
-              certType     TYPED-CERT.&id({TypedCertSet}),
-              content     TYPED-CERT.&Type ({TypedCertSet}{@certType})
-          }
-
-TypedCertSet TYPED-CERT ::= {
-   ... -- None defined in this document --
-      }
-~~~
-
-"TypedFlatCert" is a certificate that does not have a valid ASN.1
-encoding.
-These are often compact or implicit certificates used by smart cards.
-certType indicates the format of the data in the
-certBody field, and ideally refers to a published specification.
-
-~~~
-TypedFlatCert ::= SEQUENCE {
-    certType OBJECT IDENTIFIER,
-    certBody OCTET STRING
-}
-~~~
 
 # IANA Considerations
 


### PR DESCRIPTION
Closes #127 

We need to convince ourselves that this change does not affect the wire format ... ie that none of the appendices need to change.