### PR TITLE
Removed hint

### DIFF
--- a/draft-ietf-lamps-csr-attestation.md
+++ b/draft-ietf-lamps-csr-attestation.md
@@ -71,7 +71,7 @@ normative:
   RFC4211:
   RFC2986:
   RFC6268:
-  RFC5280:  
+  RFC5280:
   ASN1-2002:
     author:
       org: ITU-T


### PR DESCRIPTION
Per IETF discussion I am proposing to remove the optional hint from the CSR attestation draft.

Accepting this PR also voids the need to consider https://github.com/lamps-wg/csr-attestation/pull/143 and https://github.com/lamps-wg/csr-attestation/pull/133