### PR TITLE
Fixed DICE asn.1 example

### DIFF
--- a/CSR-ATTESTATION-2023.asn
+++ b/CSR-ATTESTATION-2023.asn
@@ -2,7 +2,7 @@ CSR-ATTESTATION-2023
            {iso(1) identified-organization(3) dod(6) internet(1) security(5)
        mechanisms(5) pkix(7) id-mod(0) id-mod-pkix-attest-01(TBDMOD)}
 
-DEFINITIONS IMPLICIT TAGS ::= BEGIN
+CsrAttestation DEFINITIONS IMPLICIT TAGS ::= BEGIN
 
 EXPORTS ALL;
 

--- a/CSR-ATTESTATION-WITH-DICE-CMW.asn
+++ b/CSR-ATTESTATION-WITH-DICE-CMW.asn
@@ -5,8 +5,9 @@ IMPORTS
 
 tcg-dice-conceptual-message-wrapper FROM TcgDiceAttestation
 DiceConceptualMessageWrapper FROM TcgDiceAttestation
-
-EvidenceStatementSet FROM CsrAttestation 
+cg-dice-TcbInfo FROM TcgDiceAttestation
+DiceTcbInfo FROM TcgDiceAttestation
+EvidenceStatementSet FROM CsrAttestation
 ;
 
 tcgDiceCmwEvidenceStatementES EVIDENCE-STATEMENT ::= { 
@@ -19,7 +20,7 @@ tcgDiceTcbInfoEvidenceStatementES EVIDENCE-STATEMENT ::= {
 
 EvidenceStatementSet EVIDENCE-STATEMENT ::= {
   tcgDiceEvidenceStatementES, 
-  tcgDiceTcbInfoEvidenceStatementES, 
+  tcgDiceTcbInfoEvidenceStatementES 
   ...
 }
 END

--- a/CSR-ATTESTATION-WITH-DICE-CMW.asn
+++ b/CSR-ATTESTATION-WITH-DICE-CMW.asn
@@ -1,11 +1,100 @@
 
-tcgDiceEvidenceStatementES EVIDENCE-STATEMENT ::=
-  { ConceptualMessageWrapper IDENTIFIED BY tcg-dice-conceptual-message-wrapper }
+CsrAttestationDiceExample DEFINITIONS IMPLICIT TAGS ::= BEGIN
 
--- where ConceptualMessageWrapper and tcg-dice-conceptual-message-wrapper 
+IMPORTS 
+
+tcg-dice-conceptual-message-wrapper FROM TcgDiceAttestation
+DiceConceptualMessageWrapper FROM TcgDiceAttestation
+
+EvidenceStatementSet FROM CsrAttestation 
+;
+
+tcgDiceCmwEvidenceStatementES EVIDENCE-STATEMENT ::= { 
+  DiceConceptualMessageWrapper IDENTIFIED BY tcg-dice-conceptual-message-wrapper }
+
+tcgDiceTcbInfoEvidenceStatementES EVIDENCE-STATEMENT ::= {
+  DiceTcbInfo IDENTIFIED BY tcg-dice-TcbInfo }
+-- where ConceptualMessageWrapper, tcg-dice-conceptual-message-wrapper, DiceTcbInfo, and tcg-dice-TcbInfo
 -- are defined in DICE-Attestation-Architecture-Version-1.1-Revision-17_1August2023.pdf
 
 EvidenceStatementSet EVIDENCE-STATEMENT ::= {
-  tcgDiceEvidenceStatementES, ...
+  tcgDiceEvidenceStatementES, 
+  tcgDiceTcbInfoEvidenceStatementES, 
+  ...
+}
+END
+
+TcgDiceAttestation DEFINITIONS AUTOMATIC TAGS ::= BEGIN
+
+EXPORTS ALL;
+
+tcg OBJECT IDENTIFIER ::= { 2 23 133 }
+tcg-dice OBJECT IDENTIFIER ::= { tcg platformClass(5) dice(4) }
+tcg-dice-TcbInfo OBJECT IDENTIFIER ::= { tcg-dice tcbinfo(1) }
+tcg-dice-MultiTcbInfo OBJECT IDENTIFIER ::= {tcg-dice multitcbinfo(5) }
+tcg-dice-UCCS-evidence OBJECT IDENTIFIER ::= {tcg-dice uccs-evidence(6) }
+tcg-dice-manifest-evidence OBJECT IDENTIFIER ::= {tcg-dice manifest-evidience(7) }
+tcg-dice-MultiTcbInfoComp OBJECT IDENTIFIER ::= {tcg-dice multitcbinfocomp(8) }
+tcg-dice-conceptual-message-wrapper OBJECT IDENTIFIER ::= { tcg-dice cmw(9) }
+
+DiceConceptualMessageWrapper ::= SEQUENCE {
+  cmw OCTECT STRING
 }
 
+DiceTcbInfo ::= SEQUENCE {
+  vendor [0] IMPLICIT UTF8String OPTIONAL,
+  model [1] IMPLICIT UTF8String OPTIONAL,
+  version [2] IMPLICIT UTF8String OPTIONAL,
+  svn [3] IMPLICIT INTEGER OPTIONAL,
+  layer [4] IMPLICIT INTEGER OPTIONAL,
+  index [5] IMPLICIT INTEGER OPTIONAL,
+  fwids [6] IMPLICIT FWIDLIST OPTIONAL,
+  flags [7] IMPLICIT OperationalFlags OPTIONAL,
+  vendorInfo [8] IMPLICIT OCTET STRING OPTIONAL,
+  type [9] IMPLICIT OCTET STRING OPTIONAL,
+  flagsMask [10]IMPLICIT OperationalFlagsMask OPTIONAL,
+  integrityRegisters [11] IMPLICIT IrList OPTIONAL
+}
+
+FWIDLIST ::= SEQUENCE SIZE (1..MAX) OF FWID
+  FWID ::= SEQUENCE {
+  hashAlg OBJECT IDENTIFIER,
+  digest OCTET STRING
+}
+
+OperationalFlags ::= BIT STRING {
+  notConfigured (0),
+  notSecure (1),
+  recovery (2),
+  debug (3),
+  notReplayProtected (4),
+  notIntegrityProtected (5),
+  notRuntimeMeasured (6),
+  notImmutable (7),
+  notTcb (8),
+  fixedWidth (31)
+}
+
+OperationalFlagsMask ::= BIT STRING {
+  notConfigured (0),
+  notSecure (1),
+  recovery (2),
+  debug (3),
+  notReplayProtected (4),
+  notIntegrityProtected (5),
+  notRuntimeMeasured (6),
+  notImmutable (7),
+  notTcb (8),
+  fixedWidth (31)
+}
+
+IrList ::= SEQUENCE SIZE (1..MAX) OF IntegrityRegister
+
+IntegrityRegister ::= SEQUENCE {
+  registerName IA5String OPTIONAL,
+  registerNum INTEGER OPTIONAL,
+  hashAlg OBJECT IDENTIFIER,
+  digest OCTET STRING
+}
+    
+END

--- a/CSR-ATTESTATION-WITH-DICE-CMW.asn
+++ b/CSR-ATTESTATION-WITH-DICE-CMW.asn
@@ -41,7 +41,7 @@ tcg-dice-conceptual-message-wrapper OBJECT IDENTIFIER ::= { tcg-dice cmw(9) }
 tcg-dice-TcbFreshness OBJECT IDENTIFIER ::= { tcg-dice tcb-freshness(11) }
 
 DiceConceptualMessageWrapper ::= SEQUENCE {
-  cmw OCTECT STRING
+  cmw OCTET STRING
 }
 
 DiceTcbInfo ::= SEQUENCE {

--- a/CSR-ATTESTATION-WITH-DICE-CMW.asn
+++ b/CSR-ATTESTATION-WITH-DICE-CMW.asn
@@ -5,7 +5,7 @@ IMPORTS
 
 tcg-dice-conceptual-message-wrapper FROM TcgDiceAttestation
 DiceConceptualMessageWrapper FROM TcgDiceAttestation
-cg-dice-TcbInfo FROM TcgDiceAttestation
+tcg-dice-TcbInfo FROM TcgDiceAttestation
 DiceTcbInfo FROM TcgDiceAttestation
 EvidenceStatementSet FROM CsrAttestation
 ;

--- a/CSR-ATTESTATION-WITH-DICE-CMW.asn
+++ b/CSR-ATTESTATION-WITH-DICE-CMW.asn
@@ -16,7 +16,7 @@ tcgDiceCmwEvidenceStatementES EVIDENCE-STATEMENT ::= {
 tcgDiceTcbInfoEvidenceStatementES EVIDENCE-STATEMENT ::= {
   DiceTcbInfo IDENTIFIED BY tcg-dice-TcbInfo }
 -- where ConceptualMessageWrapper, tcg-dice-conceptual-message-wrapper, DiceTcbInfo, and tcg-dice-TcbInfo
--- are defined in DICE-Attestation-Architecture-Version-1.1-Revision-17_1August2023.pdf
+-- are defined in DICE-Attestation-Architecture-Version-1.1-Revision-18_6Jan2024.pdf
 
 EvidenceStatementSet EVIDENCE-STATEMENT ::= {
   tcgDiceEvidenceStatementES, 

--- a/CSR-ATTESTATION-WITH-DICE-CMW.asn
+++ b/CSR-ATTESTATION-WITH-DICE-CMW.asn
@@ -31,11 +31,14 @@ EXPORTS ALL;
 tcg OBJECT IDENTIFIER ::= { 2 23 133 }
 tcg-dice OBJECT IDENTIFIER ::= { tcg platformClass(5) dice(4) }
 tcg-dice-TcbInfo OBJECT IDENTIFIER ::= { tcg-dice tcbinfo(1) }
+tcg-dice-endorsement-manifest-uri OBJECT IDENTIFIER ::= { tcg-dice manifest-uri(3) }
+tcg-dice-Ueid OBJECT IDENTIFIER ::= { tcg-dice ueid(4) }
 tcg-dice-MultiTcbInfo OBJECT IDENTIFIER ::= {tcg-dice multitcbinfo(5) }
 tcg-dice-UCCS-evidence OBJECT IDENTIFIER ::= {tcg-dice uccs-evidence(6) }
 tcg-dice-manifest-evidence OBJECT IDENTIFIER ::= {tcg-dice manifest-evidience(7) }
 tcg-dice-MultiTcbInfoComp OBJECT IDENTIFIER ::= {tcg-dice multitcbinfocomp(8) }
 tcg-dice-conceptual-message-wrapper OBJECT IDENTIFIER ::= { tcg-dice cmw(9) }
+tcg-dice-TcbFreshness OBJECT IDENTIFIER ::= { tcg-dice tcb-freshness(11) }
 
 DiceConceptualMessageWrapper ::= SEQUENCE {
   cmw OCTECT STRING

--- a/CSR-ATTESTATION-WITH-DICE-CMW.asn
+++ b/CSR-ATTESTATION-WITH-DICE-CMW.asn
@@ -100,5 +100,41 @@ IntegrityRegister ::= SEQUENCE {
   hashAlg OBJECT IDENTIFIER,
   digest OCTET STRING
 }
-    
+
+EndorsementManifestURI ::= SEQUENCE {
+  emUri	UTF8String
+}
+
+TcgUeid ::= SEQUENCE {
+  ueid OCTET STRING
+}
+
+DiceTcbInfoSeq ::= SEQUENCE SIZE (1..MAX) OF DiceTcbInfo
+
+DiceTcbInfoComp ::= SEQUENCE SIZE (1..MAX) OF TcbInfoComp
+
+TcbInfoComp ::= SEQUENCE {
+  commonFields [0] IMPLICIT DiceTcbInfo,
+  evidenceValues [1] IMPLICIT DiceTcbInfoSeq
+}
+
+UccsEvidence ::= SEQUENCE {
+  uccs OCTET STRING
+} 
+
+Manifest ::= SEQUENCE {
+  format ManifestFormat,
+  manifest OCTET STRING
+}
+
+ManifestFormat ::= ENUMERATED {
+  swid-xml		(0),
+  coswid-cbor		(1),
+  coswid-json		(2),
+  tagged-cbor		(3)
+}
+
+DiceTcbFreshness ::= SEQUENCE {
+  nonce OCTET STRING
+}
 END

--- a/draft-ietf-lamps-csr-attestation.md
+++ b/draft-ietf-lamps-csr-attestation.md
@@ -1210,7 +1210,7 @@ the result of CBOR encoding the CMW collection shown below
 {::include CSR-ATTESTATION-2023.asn}
 ~~~
 
-## TCG DICE ConceptualMessageWrapper in CSR
+## TCG DICE Example in ASN.1
 
 This section gives an example of extending the ASN.1 module above to carry an existing ASN.1-based evidence statement.
 The example used is the Trusted Computing Group DICE Attestation Conceptual Message Wrapper, as defined in {{TCGDICE1.1}}.
@@ -1219,7 +1219,7 @@ The example used is the Trusted Computing Group DICE Attestation Conceptual Mess
 {::include CSR-ATTESTATION-WITH-DICE-CMW.asn}
 ~~~
 
-## TCG DICE ConceptualMessageWrapper in CSR
+## TCG DICE TcbInfo Example in CSR
 
 This section gives an example of extending the ASN.1 module above to carry an existing ASN.1-based evidence statement.
 The example used is the Trusted Computing Group DiceTcbInfo, as defined in {{TCGDICE1.1}}.

--- a/draft-ietf-lamps-csr-attestation.md
+++ b/draft-ietf-lamps-csr-attestation.md
@@ -654,7 +654,7 @@ It lists entries for several evidence encoding OIDs including an entry for the C
 | 2 23 133 5 4 9   | tcg-dice-conceptual-message-wrapper | {{TCGDICE1.1}}   |  TCG       |
 | 2 23 133 5 4 11  | tcg-dice-TcbFreshness        | {{TCGDICE1.1}}   |  TCG              |
 | 2 23 133 20 1    | tcg-attest-tpm-certify       | Private Registry |  TCG              |
-| 1 3 6 1 5 5 7 1 TBA | id-pe-cmw                    | {{I-D.ietf-rats-msg-wrap} | IETF     |
+| 1 3 6 1 5 5 7 1 35 | id-pe-cmw                    | {{I-D.ietf-rats-msg-wrap} | IETF     |
 {: #tab-ae-reg title="Initial Contents of the Attestation Evidence OID Registry"}
 
 The current registry values can be retrieved from the IANA online website.

--- a/draft-ietf-lamps-csr-attestation.md
+++ b/draft-ietf-lamps-csr-attestation.md
@@ -644,12 +644,15 @@ It lists entries for several evidence encoding including an entry for the Concep
 
 | OID              | Description                  | Reference(s)     | Change Controller |
 |------------------|------------------------------|----------------  |-------------------|
-| 2 23 133 5 4 1   | DiceTcbInfo                  | {{TCGDICE1.1}}   |  TCG              |
-| 2 23 133 5 4 5   | DiceMultiTcbInfo             | {{TCGDICE1.1}}   |  TCG              |
-| 2 23 133 5 4 6   | DiceUccsEvidence             | {{TCGDICE1.1}}   |  TCG              |
-| 2 23 133 5 4 7   | DiceManifestEvidence         | {{TCGDICE1.1}}   |  TCG              |
-| 2 23 133 5 4 8   | DiceTcbInfoComp              | {{TCGDICE1.1}}   |  TCG              |
-| 2 23 133 5 4 9   | DiceConceptualMessageWrapper | {{TCGDICE1.1}}   |  TCG              |
+| 2 23 133 5 4 1   | tcg-dice-TcbInfo             | {{TCGDICE1.1}}   |  TCG              |
+| 2 23 133 5 4 3   | tcg-dice-endorsement-manifest-uri | {{TCGDICE1.1}}   |  TCG         |
+| 2 23 133 5 4 4   | tcg-dice-Ueid                | {{TCGDICE1.1}}   |  TCG              |
+| 2 23 133 5 4 5   | tcg-dice-MultiTcbInfo        | {{TCGDICE1.1}}   |  TCG              |
+| 2 23 133 5 4 6   | tcg-dice-UCCS-evidence       | {{TCGDICE1.1}}   |  TCG              |
+| 2 23 133 5 4 7   | tcg-dice-manifest-evidence   | {{TCGDICE1.1}}   |  TCG              |
+| 2 23 133 5 4 8   | tcg-dice-MultiTcbInfoComp    | {{TCGDICE1.1}}   |  TCG              |
+| 2 23 133 5 4 9   | tcg-dice-conceptual-message-wrapper | {{TCGDICE1.1}}   |  TCG       |
+| 2 23 133 5 4 11  | tcg-dice-TcbFreshness        | {{TCGDICE1.1}}   |  TCG              |
 | 2 23 133 20 1    | tcg-attest-tpm-certify       | Private Registry |  TCG              |
 {: #tab-ae-reg title="Initial Contents of the Attestation Evidence OID Registry"}
 

--- a/draft-ietf-lamps-csr-attestation.md
+++ b/draft-ietf-lamps-csr-attestation.md
@@ -640,7 +640,7 @@ party that registered the OID.
 ### Initial Registry Contents
 
 The initial registry contents is shown in the table below.
-It lists entries for several evidence encoding including an entry for the Conceptual Message Wrapper (CMW) {{I-D.ietf-rats-msg-wrap}}.
+It lists entries for several evidence encoding OIDs including an entry for the Conceptual Message Wrapper (CMW) {{I-D.ietf-rats-msg-wrap}}.
 
 | OID              | Description                  | Reference(s)     | Change Controller |
 |------------------|------------------------------|----------------  |-------------------|
@@ -654,6 +654,7 @@ It lists entries for several evidence encoding including an entry for the Concep
 | 2 23 133 5 4 9   | tcg-dice-conceptual-message-wrapper | {{TCGDICE1.1}}   |  TCG       |
 | 2 23 133 5 4 11  | tcg-dice-TcbFreshness        | {{TCGDICE1.1}}   |  TCG              |
 | 2 23 133 20 1    | tcg-attest-tpm-certify       | Private Registry |  TCG              |
+| 1 3 6 1 5 5 7 1 TBA | id-pe-cmw                    | {{I-D.ietf-rats-msg-wrap} | IETF     |
 {: #tab-ae-reg title="Initial Contents of the Attestation Evidence OID Registry"}
 
 The current registry values can be retrieved from the IANA online website.


### PR DESCRIPTION
Updated DICE examples to create a evidence bundle containing a DICE cmw and DiceTcbInfo.  Added CsrAttestation name to the definition in CSR-ATTESTATION-2023.asn file so that imports would compile.