### PR TITLE
Remove CertificateAlternatives

### DIFF
--- a/CSR-ATTESTATION-2023.asn
+++ b/CSR-ATTESTATION-2023.asn
@@ -33,17 +33,6 @@ FROM SecureMimeMessageV3dot1
 -- Branch for attestation statement types
 id-ata OBJECT IDENTIFIER ::= { id-pkix (TBD1) }
 
-
-CertificateAlternatives ::=
-   CHOICE {
-      cert              Certificate,
-                           -- Using the Certificate ASN.1
-                           -- structure as defined in RFC 5280.
-      typedCert     [0] TypedCert,
-      typedFlatCert [1] TypedFlatCert,
-      ...
-   }
-
 TYPED-CERT ::= TYPE-IDENTIFIER
 
 TypedCert ::= SEQUENCE {

--- a/CSR-ATTESTATION-2023.asn
+++ b/CSR-ATTESTATION-2023.asn
@@ -33,22 +33,6 @@ FROM SecureMimeMessageV3dot1
 -- Branch for attestation statement types
 id-ata OBJECT IDENTIFIER ::= { id-pkix (TBD1) }
 
-TYPED-CERT ::= TYPE-IDENTIFIER
-
-TypedCert ::= SEQUENCE {
-      certType     TYPED-CERT.&id({TypedCertSet}),
-      content     TYPED-CERT.&Type ({TypedCertSet}{@certType})
-  }
-
-TypedCertSet TYPED-CERT ::= {
-   ... -- None defined in this document --
-  }
-
-TypedFlatCert ::= SEQUENCE {
-    certType OBJECT IDENTIFIER,
-    certBody OCTET STRING
-}
-
 EVIDENCE-STATEMENT ::= TYPE-IDENTIFIER
 
 EvidenceStatementSet EVIDENCE-STATEMENT ::= {


### PR DESCRIPTION
We wanted to use the CMS defined CertificateChoices structure instead of our own CertificateAlternatives structure. We forgot to update the ASN.1 file accordingly. This PR makes this changes.
