### PR TITLE
Update CSR-ATTESTATION-2025.asn - Update the use of CertificateChoices to a properly constrained ASN1 2002 definition.

### DIFF
--- a/CSR-ATTESTATION-2025.asn
+++ b/CSR-ATTESTATION-2025.asn
@@ -86,12 +86,11 @@ ext-ar EXTENSION ::= {
   IDENTIFIED BY id-aa-ar
 }
 
+LimitedCertChoices ::= CertificateChoices (WITH COMPONENTS {certificate, other})
+
 EvidenceBundle ::= SEQUENCE {
    evidences SEQUENCE SIZE (1..MAX) OF EvidenceStatement,
-   certs SEQUENCE SIZE (1..MAX) OF CertificateChoices OPTIONAL,
-      -- CertificateChoices MUST NOT contain the depreciated
-      -- certificate structures or attribute certificates,
-      -- see Section 10.2.2 of [RFC5652]
+   certs SEQUENCE SIZE (1..MAX) OF LimitedCertChoices OPTIONAL
 }
 
 AttestationResultBundle ::= SEQUENCE SIZE (1..MAX) 


### PR DESCRIPTION
This updates the ASN1 module to use the proper ASN1 2002 constraints language to limit CertificateChoices to "certificate" and "other".  LimitedCertChoices maps exactly to the requirements in the removed comment text.